### PR TITLE
Omit release date from search query by default (closes #16)

### DIFF
--- a/packages/addon/src/addon.ts
+++ b/packages/addon/src/addon.ts
@@ -109,10 +109,16 @@ builder.defineStreamHandler(async ({ id, type, config }) => {
     }
 
     const meta = await publicMetaProvider(id, type);
-    const searchQuery = buildSearchQuery(type, meta);
 
     const api = new EasynewsAPI(config);
-    const res = await api.search(searchQuery);
+
+    let res = await api.search(
+      buildSearchQuery(type, { ...meta, year: undefined })
+    );
+
+    if (res?.data?.length <= 1 && meta.year !== undefined) {
+      res = await api.search(buildSearchQuery(type, meta));
+    }
 
     if (!res || !res.data) {
       return { streams: [] };


### PR DESCRIPTION
Appending the year in the search query tends to yield little results. The full query with year is still performed as a fall back though.