### PR TITLE
Fix Android TV support (closes #21)

### DIFF
--- a/packages/addon/src/utils.ts
+++ b/packages/addon/src/utils.ts
@@ -54,7 +54,7 @@ export function getFileExtension(file: FileData) {
 }
 
 export function getPostTitle(file: FileData) {
-  return `${file['10'] ?? ''}${getFileExtension(file)}`;
+  return file['10'] ?? '';
 }
 
 export function getDuration(file: FileData) {

--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -72,10 +72,10 @@ export class EasynewsAPI {
     let pageNr = 1;
 
     while (true) {
-      res = await this.search({ ...options, pageNr: 1 });
+      res = await this.search({ ...options, pageNr });
 
       // No more results.
-      if (res.data.length === 0) {
+      if (res.data.length === 0 || data[0]?.['0'] === res.data[0]?.['0']) {
         break;
       }
 


### PR DESCRIPTION
Turns out it was a multitude of issues:
- Spaces in the `id` field (on other platforms its not an issue because it gets urlencoded i presume).
- Use of the deprecated `title` field in the `stream` object (`description` was also set, which is its successor).
- Missing `fileExtension` and `videoSize` fields in the `behaviorHints` field (probably not the issue though).
- Unnecessary 'authentication' suffix at the end of the stream url.
- Infinite loop in the 'search all' api method