### PR TITLE
Explicitly use EN V2 API domain (closes #43)

### DIFF
--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -2,7 +2,7 @@ import { createBasic } from './utils';
 import { EasynewsSearchResponse, FileData, SearchOptions } from './types';
 
 export class EasynewsAPI {
-  private readonly baseUrl = 'https://members.easynews.com';
+  private readonly baseUrl = 'https://members2.easynews.com';
   private readonly headers: Headers;
 
   constructor(options: { username: string; password: string }) {
@@ -75,7 +75,10 @@ export class EasynewsAPI {
       res = await this.search({ ...options, pageNr });
 
       // No more results.
-      if (res.data.length === 0 || data[0]?.['0'] === res.data[0]?.['0']) {
+      if (
+        (res.data ?? []).length === 0 ||
+        data[0]?.['0'] === res.data[0]?.['0']
+      ) {
         break;
       }
 


### PR DESCRIPTION
The new Easynews V3 API requires cookie authentication. Cookies only last for around 4 days. This is harder to implement than the previous V2 API because cookies would need to be managed by the addon. Thus we'll try to keep using the V2 API endpoint for as long as possible.