### PR TITLE
Fix ExoPlayer compatibility by implementing authentication proxy

### DIFF
--- a/addon.ts
+++ b/addon.ts
@@ -1,0 +1,285 @@
+import {
+  Cache,
+  MetaDetail,
+  MetaVideo,
+  Stream,
+  AddonBuilder,
+} from '@stremio-addon/sdk';
+import { catalog, manifest } from './manifest.js';
+import {
+  buildSearchQuery,
+  createStreamPath,
+  createStreamUrl,
+  createThumbnailUrl,
+  getDuration,
+  getFileExtension,
+  getPostTitle,
+  getQuality,
+  getSize,
+  isBadVideo,
+  logError,
+  matchesTitle,
+} from './utils.js';
+import { EasynewsAPI, SearchOptions, createBasic } from '@easynews/api';
+import { publicMetaProvider } from './meta.js';
+import { fromHumanReadable, toDirection } from './sort-option.js';
+import { landingTemplate } from '@stremio-addon/compat/landing-template';
+
+type Config = {
+  username: string;
+  password: string;
+  sort1?: string;
+  sort1Direction?: string;
+  sort2?: string;
+  sort2Direction?: string;
+  sort3?: string;
+  sort3Direction?: string;
+};
+
+let workerBaseUrl = '';
+
+export function setWorkerBaseUrl(url: string) {
+  workerBaseUrl = url;
+}
+
+const builder = new AddonBuilder(manifest);
+
+const prefix = `${catalog.id}:`;
+
+builder.defineCatalogHandler<Config>(async ({ extra: { search } }) => {
+  if (!search) {
+    return {
+      metas: [],
+    };
+  }
+
+  return {
+    metas: [
+      {
+        id: `${prefix}${encodeURIComponent(search)}`,
+        name: search,
+        type: 'tv',
+        logo: manifest.logo,
+        background: manifest.background,
+        posterShape: 'square',
+        poster: manifest.logo,
+        description: `Provides search results from Easynews for '${search}'`,
+      },
+    ],
+    cacheMaxAge: 3600 * 24 * 30, // The returned data is static so it may be cached for a long time (30 days).
+  };
+});
+
+builder.defineMetaHandler<Config>(
+  async ({ id, type, config: { username, password } }) => {
+    try {
+      if (!id.startsWith(catalog.id)) {
+        return { meta: null as unknown as MetaDetail };
+      }
+
+      const search = decodeURIComponent(id.replace(prefix, ''));
+
+      const videos: MetaVideo[] = [];
+
+      const api = new EasynewsAPI({ username, password });
+      const res = await api.searchAll({ query: search });
+
+      for (const file of res?.data ?? []) {
+        const title = getPostTitle(file);
+
+        if (isBadVideo(file) || !matchesTitle(title, search, false)) {
+          continue;
+        }
+
+        videos.push({
+          id: `${prefix}${file.sig}`,
+          released: new Date(file['5']).toISOString(),
+          title,
+          overview: file['6'],
+          thumbnail: createThumbnailUrl(res, file),
+          streams: [
+            mapStream({
+              title,
+              fullResolution: file.fullres,
+              fileExtension: getFileExtension(file),
+              duration: getDuration(file),
+              size: getSize(file),
+              url: `${createStreamUrl(res, username, password, workerBaseUrl)}/${createStreamPath(file)}`,
+              videoSize: file.rawSize,
+            }),
+          ],
+        });
+      }
+
+      return {
+        meta: {
+          id,
+          name: search,
+          type: 'tv',
+          logo: manifest.logo,
+          background: manifest.background,
+          poster: manifest.logo,
+          posterShape: 'square',
+          description: `Provides search results from Easynews for '${search}'`,
+          videos,
+        },
+        ...getCacheOptions(videos.length),
+      };
+    } catch (error) {
+      logError({
+        message: 'failed to handle meta',
+        error,
+        context: { resource: 'meta', id, type },
+      });
+      return { meta: null as unknown as MetaDetail };
+    }
+  }
+);
+
+builder.defineStreamHandler<Config>(
+  async ({ id, type, config: { username, password, ...options } }) => {
+    try {
+      if (!id.startsWith('tt')) {
+        return { streams: [] };
+      }
+
+      // Sort options are profiled as human-readable strings in the manifest.
+      // so we need to convert them back to their internal representation
+      // before passing them to the search function below.
+      const sortOptions: Partial<SearchOptions> = {
+        sort1: fromHumanReadable(options.sort1),
+        sort2: fromHumanReadable(options.sort2),
+        sort3: fromHumanReadable(options.sort3),
+        sort1Direction: toDirection(options.sort1Direction),
+        sort2Direction: toDirection(options.sort2Direction),
+        sort3Direction: toDirection(options.sort3Direction),
+      };
+
+      const meta = await publicMetaProvider(id, type);
+
+      const api = new EasynewsAPI({ username, password });
+
+      let query = buildSearchQuery(type, { ...meta, year: undefined });
+      let res = await api.search({
+        ...sortOptions,
+        query,
+      });
+
+      if (res?.data?.length <= 1 && meta.year !== undefined) {
+        query = buildSearchQuery(type, meta);
+        res = await api.search({
+          ...sortOptions,
+          query,
+        });
+      }
+
+      if (!res || !res.data) {
+        return { streams: [] };
+      }
+
+      const streams: Stream[] = [];
+
+      for (const file of res.data ?? []) {
+        const title = getPostTitle(file);
+
+        if (isBadVideo(file)) {
+          continue;
+        }
+
+        // For series there are multiple possible queries that could match the title.
+        // We check if at least one of them matches.
+        if (type === 'series') {
+          const queries = [
+            // full query with season and episode (and optionally year)
+            query,
+            // query with episode only
+            buildSearchQuery(type, { name: meta.name, episode: meta.episode }),
+          ];
+
+          if (!queries.some((query) => matchesTitle(title, query, false))) {
+            continue;
+          }
+        }
+
+        // Movie titles should match the query strictly.
+        // Other content types are loosely matched.
+        if (!matchesTitle(title, query, type === 'movie')) {
+          continue;
+        }
+
+        streams.push(
+          mapStream({
+            fullResolution: file.fullres,
+            fileExtension: getFileExtension(file),
+            duration: getDuration(file),
+            size: getSize(file),
+            title,
+            url: `${createStreamUrl(res, username, password, workerBaseUrl)}/${createStreamPath(file)}`,
+            videoSize: file.rawSize,
+          })
+        );
+      }
+
+      return { streams, ...getCacheOptions(streams.length) };
+    } catch (error) {
+      logError({
+        message: 'failed to handle stream',
+        error,
+        context: { resource: 'stream', id, type },
+      });
+      return { streams: [] };
+    }
+  }
+);
+
+function mapStream({
+  duration,
+  size,
+  fullResolution,
+  title,
+  fileExtension,
+  videoSize,
+  url,
+}: {
+  title: string;
+  url: string;
+  fileExtension: string;
+  videoSize: number | undefined;
+  duration: string | undefined;
+  size: string | undefined;
+  fullResolution: string | undefined;
+}): Stream {
+  const quality = getQuality(title, fullResolution);
+
+  return {
+    name: `Easynews+${quality ? `\n${quality}` : ''}`,
+    description: [
+      `${title}${fileExtension}`,
+      `🕛 ${duration ?? 'unknown duration'}`,
+      `📦 ${size ?? 'unknown size'}`,
+    ].join('\n'),
+    url: url,
+    behaviorHints: {
+      fileName: title,
+      videoSize,
+    } as Stream['behaviorHints'],
+  };
+}
+
+function getCacheOptions(itemsLength: number): Partial<Cache> {
+  if (itemsLength === 0) {
+    return {};
+  }
+
+  const oneDay = 3600 * 24;
+  const oneWeek = oneDay * 7;
+
+  return {
+    cacheMaxAge: oneWeek,
+    staleError: oneDay,
+    staleRevalidate: oneDay,
+  };
+}
+
+export const addonInterface = builder.getInterface();
+export const landingHTML = landingTemplate(addonInterface.manifest);

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,19 @@
+import { Hono } from 'hono';
+import { addonInterface, landingHTML, setWorkerBaseUrl } from '@easynews/addon';
+import { getRouter } from './router.js';
+
+const app = new Hono();
+
+// Middleware to set the base URL for proxy generation
+app.use('*', async (c, next) => {
+  const url = new URL(c.req.url);
+  const baseUrl = `${url.protocol}//${url.host}`;
+  setWorkerBaseUrl(baseUrl);
+  await next();
+});
+
+const addonRouter = getRouter(addonInterface, { landingHTML });
+
+app.route('/', addonRouter);
+
+export default app;

--- a/router.ts
+++ b/router.ts
@@ -1,0 +1,125 @@
+import { Hono } from 'hono';
+import { createRouter, type AddonInterface } from '@stremio-addon/sdk';
+
+export type Options = {
+  /**
+   * Landing page HTML.
+   */
+  landingHTML: string;
+};
+
+export function getRouter(
+  addonInterface: AddonInterface,
+  { landingHTML }: Options
+) {
+  const router = createRouter(addonInterface);
+
+  const honoRouter = new Hono();
+  
+  honoRouter.get('/', ({ html }) => html(landingHTML));
+  honoRouter.get('/config', ({ html }) => html(landingHTML)); // for reverse compatibility with the old 'hono-stremio' package
+  
+  // Proxy endpoint for ExoPlayer compatibility
+  honoRouter.get('/proxy/:encodedData', async (c) => {
+    try {
+      const { encodedData } = c.req.param();
+      
+      // Decode base64url
+      let decoded = encodedData.replace(/-/g, '+').replace(/_/g, '/');
+      while (decoded.length % 4) decoded += '=';
+      const proxyData = JSON.parse(atob(decoded));
+      
+      const { url: targetUrl, username, password } = proxyData;
+      
+      if (!targetUrl || !username || !password) {
+        return c.text('Invalid proxy data', 400);
+      }
+      
+      console.log('Proxying stream to:', new URL(targetUrl).hostname);
+      
+      // Build headers with proper authentication
+      const authHeader = 'Basic ' + btoa(`${username}:${password}`);
+      const headers: Record<string, string> = {
+        'Authorization': authHeader,
+        'User-Agent': 'Stremio-Easynews-Addon/2.0.0',
+      };
+      
+      // Forward Range header for seeking support
+      const rangeHeader = c.req.header('Range');
+      if (rangeHeader) {
+        headers['Range'] = rangeHeader;
+      }
+      
+      // Fetch from Easynews without following redirects
+      const streamResponse = await fetch(targetUrl, {
+        headers,
+        redirect: 'manual',
+      });
+      
+      console.log('Easynews response:', streamResponse.status);
+      
+      // Handle redirect to CDN
+      if (streamResponse.status >= 300 && streamResponse.status < 400) {
+        const location = streamResponse.headers.get('Location');
+        if (location) {
+          console.log('Got CDN redirect, validating...');
+          
+          // Validate CDN URL accessibility
+          try {
+            const validateResponse = await fetch(location, {
+              method: 'HEAD',
+              headers: {
+                'User-Agent': 'Stremio-Easynews-Addon/2.0.0',
+              },
+            });
+            
+            if (!validateResponse.ok) {
+              console.error('CDN validation failed:', validateResponse.status);
+              return c.text('CDN URL not accessible', 502);
+            }
+            
+            console.log('CDN validated, redirecting');
+            
+            // Return redirect to public CDN URL
+            return c.redirect(location, 302);
+            
+          } catch (error) {
+            console.error('CDN validation error:', error);
+            return c.text('CDN validation failed', 502);
+          }
+        }
+      }
+      
+      // Direct response (shouldn't normally happen with Easynews)
+      const responseHeaders: Record<string, string> = {
+        'Content-Type': streamResponse.headers.get('Content-Type') || 'video/x-matroska',
+        'Accept-Ranges': 'bytes',
+      };
+      
+      const contentLength = streamResponse.headers.get('Content-Length');
+      if (contentLength) responseHeaders['Content-Length'] = contentLength;
+      
+      const contentRange = streamResponse.headers.get('Content-Range');
+      if (contentRange) responseHeaders['Content-Range'] = contentRange;
+      
+      return new Response(streamResponse.body, {
+        status: streamResponse.status,
+        headers: responseHeaders,
+      });
+      
+    } catch (error) {
+      console.error('Proxy error:', error);
+      return c.text('Proxy failed: ' + (error as Error).message, 500);
+    }
+  });
+  
+  honoRouter.all('*', async (c) => {
+    const req = c.req.raw;
+    const res = await router(req);
+    if (res) {
+      return res;
+    }
+  });
+
+  return honoRouter;
+}

--- a/utils.ts
+++ b/utils.ts
@@ -1,0 +1,167 @@
+import { EasynewsSearchResponse, FileData } from '@easynews/api';
+import { MetaProviderResponse } from './meta.js';
+import { ContentType } from '@stremio-addon/sdk';
+import { parse as parseTorrentTitle } from 'parse-torrent-title';
+
+export function isBadVideo(file: FileData) {
+  const duration = file['14'] ?? '';
+
+  return (
+    // <= 5 minutes in duration
+    duration.match(/^\d+s/) ||
+    duration.match('^[0-5]m') ||
+    // password protected
+    file.passwd ||
+    // malicious
+    file.virus ||
+    // not a video
+    file.type.toUpperCase() !== 'VIDEO'
+  );
+}
+
+export function sanitizeTitle(title: string) {
+  return (
+    title
+      // replace common symbols with words
+      .replaceAll('&', 'and')
+      // replace common separators (., _, -, whitespace) with a single space
+      .replace(/[\.\-_:\s]+/g, ' ')
+      // remove non-alphanumeric characters except for accented characters
+      .replace(/[^\w\sÀ-ÿ]/g, '')
+      // to lowercase + remove spaces at the beginning and end
+      .toLowerCase()
+      .trim()
+  );
+}
+
+export function matchesTitle(title: string, query: string, strict: boolean) {
+  const sanitizedQuery = sanitizeTitle(query);
+
+  if (strict) {
+    const { title: movieTitle } = parseTorrentTitle(title);
+    if (movieTitle) {
+      return sanitizeTitle(movieTitle) === sanitizedQuery;
+    }
+  }
+
+  const sanitizedTitle = sanitizeTitle(title);
+  const re = new RegExp(`\\b${sanitizedQuery}\\b`, 'i'); // match the whole word; e.g. query "deadpool 2" shouldn't match "deadpool 2016"
+  return re.test(sanitizedTitle);
+}
+
+export function createStreamUrl(
+  {
+    downURL,
+    dlFarm,
+    dlPort,
+  }: Pick<EasynewsSearchResponse, 'downURL' | 'dlFarm' | 'dlPort'>,
+  username: string,
+  password: string,
+  baseProxyUrl: string
+) {
+  // Create original Easynews URL (without embedded credentials)
+  const originalUrl = `${downURL}/${dlFarm}/${dlPort}`;
+  
+  // Encode credentials + URL for proxy
+  const proxyData = {
+    url: originalUrl,
+    username,
+    password,
+  };
+  
+  // Base64url encode the proxy data
+  const encodedData = btoa(JSON.stringify(proxyData))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+  
+  return `${baseProxyUrl}/proxy/${encodedData}`;
+}
+
+export function createStreamPath(file: FileData) {
+  const postHash = file['0'] ?? '';
+  const postTitle = file['10'] ?? '';
+  const ext = file['11'] ?? '';
+
+  return `${postHash}${ext}/${postTitle}${ext}`;
+}
+
+export function getFileExtension(file: FileData) {
+  return file['2'] ?? '';
+}
+
+export function getPostTitle(file: FileData) {
+  return file['10'] ?? '';
+}
+
+export function getDuration(file: FileData) {
+  return file['14'] ?? '';
+}
+
+export function getSize(file: FileData) {
+  return file['4'] ?? '';
+}
+
+export function getQuality(
+  title: string,
+  fallbackResolution?: string
+): string | undefined {
+  const { resolution } = parseTorrentTitle(title);
+  return resolution ?? fallbackResolution;
+}
+
+export function createThumbnailUrl(
+  res: EasynewsSearchResponse,
+  file: FileData
+) {
+  const id = file['0'];
+  const idChars = id.slice(0, 3);
+  const thumbnailSlug = file['10'];
+  return `${res.thumbURL}${idChars}/pr-${id}.jpg/th-${thumbnailSlug}.jpg`;
+}
+
+export function extractDigits(value: string) {
+  const match = value.match(/\d+/);
+
+  if (match) {
+    return parseInt(match[0], 10);
+  }
+
+  return undefined;
+}
+
+export function buildSearchQuery(
+  type: ContentType,
+  meta: MetaProviderResponse
+) {
+  let query = `${meta.name}`;
+
+  if (type === 'series') {
+    if (meta.season) {
+      query += ` S${meta.season.toString().padStart(2, '0')}`;
+    }
+
+    if (meta.episode) {
+      query += `${!meta.season ? ' ' : ''}E${meta.episode.toString().padStart(2, '0')}`;
+    }
+  }
+
+  if (meta.year) {
+    query += ` ${meta.year}`;
+  }
+
+  return query;
+}
+
+export function logError(message: {
+  message: string;
+  error: unknown;
+  context: unknown;
+}) {
+  console.error(message);
+}
+
+export function capitalizeFirstLetter(str: string): string {
+  if (!str) return str;
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}


### PR DESCRIPTION
## Problem
Stremio's ExoPlayer currently falls back to libvlc when playing Easynews streams because ExoPlayer doesn't support HTTP Basic Authentication credentials embedded in URLs (e.g., `https://user:pass@host/path`).

This has been a persistent issue affecting playback performance and compatibility.

## Solution
This PR implements a proxy endpoint that:

1. **Receives proxy requests** with encoded credentials
2. **Authenticates to Easynews** using proper `Authorization` headers
3. **Follows redirects** to Easynews CDN servers
4. **Validates CDN URLs** to ensure they're accessible
5. **Returns clean public CDN URLs** that ExoPlayer can play directly

## Technical Details

### Changes Made:
- **`packages/addon/src/utils.ts`**: Modified `createStreamUrl()` to generate proxy URLs instead of embedding credentials
- **`packages/addon/src/addon.ts`**: Added `setWorkerBaseUrl()` and updated stream URL generation
- **`packages/cloudflare-worker/src/router.ts`**: Added `/proxy/:encodedData` endpoint
- **`packages/cloudflare-worker/src/index.ts`**: Middleware to inject base URL

### Flow:
Stremio → Worker Proxy → Easynews (auth) → CDN Redirect → Worker Validates → 302 to CDN → ExoPlayer 

### Benefits:
- ✅ ExoPlayer works natively (no libvlc fallback)
- ✅ Better performance and compatibility
- ✅ Proper HTTP authentication via headers
- ✅ No bandwidth through worker (direct CDN access)
- ✅ Range request support for seeking

## Testing
Tested on:
- [x] Stremio Desktop (Windows/macOS/Linux)
- [x] Stremio Android
- [x] Movies and series playback
- [x] Seeking/scrubbing
- [x] Multiple quality streams

## Breaking Changes
None. The API remains the same, only the internal URL generation changes.

