### PR TITLE
Add bingegroup to streams to enable autoplay between episodes

### DIFF
--- a/packages/addon/src/addon.ts
+++ b/packages/addon/src/addon.ts
@@ -256,6 +256,7 @@ function mapStream({
     behaviorHints: {
       fileName: title,
       videoSize,
+      bingeGroup: 'Easynews+-' + (quality || 'default'),
     } as Stream['behaviorHints'],
   };
 }


### PR DESCRIPTION
Enables autoplay so you don't have to choose a stream source between episodes. Will pick the first available stream of the same quality you just watched. 